### PR TITLE
ci: Add cargo-semver-checks to catch breaking API changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,16 @@ env:
   ACTIONS_LINTS_TOOLCHAIN: 1.86.0
 
 jobs:
+  semver-checks:
+    name: Semver Checks
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        # Pinned until cargo-semver-checks supports rustdoc format v57 (Rust 1.93+)
+        rust-toolchain: "1.92.0"
+
   tests-stable:
     name: Tests, stable toolchain
     runs-on: ubuntu-latest


### PR DESCRIPTION
Uses the official GitHub Action to verify semver compatibility on every push and PR, comparing against the latest published crate version.

Assisted-by: OpenCode (Claude Sonnet 4)