### PR TITLE
Sync lint config and CI with bootc-dev conventions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# Copied originally from https://github.com/coreos/repo-templates
-
 name: Rust
 on:
   push:
@@ -16,43 +14,31 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.86.0
 
 jobs:
-  tests-stable:
-    name: Tests, stable toolchain
+  semver-checks:
+    name: Semver Checks
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+    - uses: obi1kenobi/cargo-semver-checks-action@v2
+      with:
+        # Pinned until cargo-semver-checks supports rustdoc format v57 (Rust 1.93+)
+        rust-toolchain: "1.92.0"
+
+  build-test-lint:
+    name: Build, Test & Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@v1
+        uses: actions/checkout@v6
+      - name: Set up Rust
+        uses: bootc-dev/actions/setup-rust@main
+      - name: Install tools
+        uses: taiki-e/install-action@v2
         with:
-          toolchain: stable
-      - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
-      - name: cargo build
-        run: cargo build --all-targets --all-features
-      - name: cargo test
-        run: cargo test --all-targets --all-features
-      # https://github.com/rust-lang/cargo/issues/6669
-      - name: cargo test --doc
-        run: cargo test --doc --all-features
-  linting:
-    name: Lints, pinned toolchain
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: ${{ env.ACTIONS_LINTS_TOOLCHAIN }}
-          components: rustfmt, clippy
-      - name: Cache build artifacts
-        uses: Swatinem/rust-cache@v2
-      - name: cargo fmt (check)
-        run: cargo fmt -- --check -l
-      - name: cargo clippy (warnings)
-        run: cargo clippy --all-targets --all-features -- -D warnings
+          tool: just
+      - name: Install rustfmt and clippy
+        run: rustup component add rustfmt clippy
+      - name: just ci
+        run: just ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,24 @@ olpc-cjson = "0.1"
 cjson = "0.1.2"
 # For round trip testing
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
+
+# Synchronized with https://github.com/bootc-dev/bootc/blob/main/Cargo.toml
+[lints.rust]
+# No unsafe code in this crate
+unsafe_code = "forbid"
+# Absolutely must handle errors
+unused_must_use = "forbid"
+# missing_docs is set per-target via #![deny(missing_docs)] in lib.rs
+# because cargo lints apply to all targets including examples.
+missing_debug_implementations = "deny"
+# Feel free to comment this one out locally during development of a patch.
+dead_code = "deny"
+
+[lints.clippy]
+# These should only be in local code
+dbg_macro = "deny"
+todo = "deny"
+# These two are in my experience the lints which are most likely
+# to trigger, and among the least valuable to fix.
+needless_borrow = "allow"
+needless_borrows_for_generic_args = "allow"

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,33 @@
+# Build everything
+build:
+    cargo build --all-targets --all-features
+
+# Run all tests using nextest
+test:
+    #!/bin/bash
+    set -euo pipefail
+    if command -v cargo-nextest &>/dev/null; then
+        cargo nextest run --all-features
+    else
+        cargo test --all-targets --all-features
+    fi
+    # https://github.com/rust-lang/cargo/issues/6669
+    cargo test --doc --all-features
+
+# Check formatting
+fmt-check:
+    cargo fmt -- --check -l
+
+# Run clippy
+clippy:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# Full lint check (formatting + clippy), mirrors CI
+lint: fmt-check clippy
+
+# Run semver checks against the last published version
+semver-check:
+    cargo semver-checks
+
+# Lint and test (used by CI, and for local development)
+ci: lint test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 #![doc = include_str!("../README.md")]
-#![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
 mod floatformat;
@@ -55,7 +54,7 @@ impl ObjectKey {
             if let Some(kind) = e.io_error_kind() {
                 Error::new(kind, "I/O error")
             } else {
-                Error::new(ErrorKind::Other, e.to_string())
+                Error::other(e.to_string())
             }
         })
     }
@@ -160,10 +159,7 @@ impl CanonicalFormatter {
     /// Returns a mutable reference to the top of the object stack.
     fn obj_mut(&mut self) -> Result<&mut Object> {
         self.object_stack.last_mut().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Other,
-                "serde_json called an object method without calling begin_object first",
-            )
+            Error::other("serde_json called an object method without calling begin_object first")
         })
     }
 }
@@ -292,8 +288,7 @@ impl Formatter for CanonicalFormatter {
 
     fn end_object<W: Write + ?Sized>(&mut self, writer: &mut W) -> Result<()> {
         let object = self.object_stack.pop().ok_or_else(|| {
-            Error::new(
-                ErrorKind::Other,
+            Error::other(
                 "serde_json called Formatter::end_object object method
                  without calling begin_object first",
             )


### PR DESCRIPTION
Add [lints.rust] and [lints.clippy] sections to Cargo.toml matching the bootc lint policy. Replace the hardcoded ACTIONS_LINTS_TOOLCHAIN pin (1.86.0) with bootc-dev/actions/setup-rust which uses stable Rust. Add semver-checks job and a Justfile for local development.

Fix clippy::io_other_error warnings by using Error::other() instead of Error::new(ErrorKind::Other, ...). Remove the redundant #![forbid(unsafe_code)] attribute from lib.rs since unsafe_code=forbid is now configured in Cargo.toml.

Assisted-by: OpenCode (Claude claude-opus-4-6)